### PR TITLE
Reorganize package.js and remove unused deps

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import io from 'socket.io-client'
+import io from 'socket.io-client';
 
 import App from './components/App';
 
-const socket = io('http://localhost:3000')
+const socket = io('http://localhost:3000');
 
 ReactDOM.render(
   <App socket={socket} />,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "server": "nodemon ./server/server.js",
     "client": "cd client && webpack --watch",
-    "demo": "concurrently --kill-others 'mongod' 'npm run server' 'npm run client'",
+    "dev": "concurrently --kill-others 'mongod' 'npm run server' 'npm run client'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -20,36 +20,31 @@
   },
   "homepage": "https://github.com/hewp/crumbs#readme",
   "dependencies": {
+    "bluebird": "^3.4.1",
+    "body-parser": "^1.15.2",
+    "bootstrap": "^3.3.6",
+    "cors": "^2.7.1",
+    "express": "^4.14.0",
+    "jquery": "^3.1.0",
+    "moment": "^2.14.1",
+    "mongoose": "^4.5.4",
+    "morgan": "^1.7.0",
+    "react": "^15.2.1",
+    "react-bootstrap": "^0.29.5",
+    "react-dom": "^15.2.1",
+    "socket.io": "^1.4.8"
+  },
+  "devDependencies": {
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
-    "bluebird": "^3.4.1",
-    "body-parser": "^1.15.2",
-    "bootstrap": "^3.3.6",
     "concurrently": "^2.2.0",
-    "cors": "^2.7.1",
-    "eslint": "^3.1.1",
-    "eslint-plugin-import": "^1.11.1",
-    "eslint-plugin-jsx-a11y": "^2.0.1",
-    "express": "^4.14.0",
-    "jquery": "^3.1.0",
-    "moment": "^2.14.1",
-    "mongodb": "^2.2.1",
-    "mongoose": "^4.5.4",
-    "morgan": "^1.7.0",
-    "path": "^0.12.7",
-    "promise": "^7.1.1",
-    "react": "^15.2.1",
-    "react-bootstrap": "^0.29.5",
-    "react-dom": "^15.2.1",
-    "request": "^2.73.0",
-    "socket.io": "^1.4.8",
-    "webpack": "^1.13.1"
-  },
-  "devDependencies": {
     "eslint": "^3.1.1",
     "eslint-config-airbnb": "^9.0.1",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-import": "^1.11.1",
+    "eslint-plugin-jsx-a11y": "^2.0.1",
+    "eslint-plugin-react": "^5.2.2",
+    "webpack": "^1.13.1"
   }
 }


### PR DESCRIPTION
Removed a lot of unused dependencies and moved dev dependencies to the devDependencies section.

Renamed npm script "demo" to "dev"

To run the mongo server and webpack use:

```
npm run dev
```
